### PR TITLE
Bug Fix LIS2DH Temperature Reading

### DIFF
--- a/drivers/mg100_lis2dh/mg100_lis2dh.c
+++ b/drivers/mg100_lis2dh/mg100_lis2dh.c
@@ -77,7 +77,7 @@ static int lis2dh_sample_fetch_temp(const struct device *dev)
 		 *  temperature that must be added to the reference temperature set
 		 *  for your board to return an absolute temperature in celsius.
 		 */
-		lis2dh->temp_sample = TEMP_REFERENCE + temp_raw[1];
+		lis2dh->temp_sample = TEMP_REFERENCE + (int8_t)temp_raw[1];
 	}
 
 	return ret;


### PR DESCRIPTION
Temperature data is stored inside OUT_TEMP_H as 2’s complement data (signed)

Bug fix according to issue #1 opened by @JusbeR 