### PR TITLE
file system utils: Add missing log_strdup in fsu_find

### DIFF
--- a/utilities/source/file_system_utilities.c
+++ b/utilities/source/file_system_utilities.c
@@ -126,7 +126,7 @@ void fsu_list_directory(const char *path)
 		}
 		LOG_DBG("  %c %u %s\n",
 			(entry.type == FS_DIR_ENTRY_FILE) ? 'F' : 'D',
-			entry.size, entry.name);
+			entry.size, log_strdup(entry.name));
 	}
 
 	(void)fs_closedir(&dir);


### PR DESCRIPTION
Added missing log_strdup in LOG_DBG which lists the directories
founds